### PR TITLE
Add meta descriptions and SEO links

### DIFF
--- a/src/components/common/Welcome.astro
+++ b/src/components/common/Welcome.astro
@@ -41,8 +41,13 @@ import OneCardServices from "@/src/components/layout/OneCardServices.astro";
         eficiencia energética, la continuidad operativa y el soporte técnico especializado.
       </p>
       <p class="text-gray-700">
-        Actualmente, somos <span class="font-semibold text-[#0e3e96]"
-          >distribuidores autorizados de Ecochillers®</span
+        Actualmente, somos
+        <a
+          href="https://ecochillers.com"
+          target="_blank"
+          rel="noopener"
+          class="font-semibold text-[#0e3e96] underline"
+          >distribuidores autorizados de Ecochillers®</a
         >, una marca mexicana reconocida por su innovación en chillers
         industriales de bajo consumo. Esta alianza nos permite ofrecer
         <span class="italic text-[#0e3e96]"

--- a/src/components/landings/HydraulicLanding.astro
+++ b/src/components/landings/HydraulicLanding.astro
@@ -1,6 +1,7 @@
 ---
 
 ---
+import Image from "astro/components/Image.astro"
 
 <!-- TUBERÍA HIDRÁULICA -->
 <div
@@ -33,10 +34,13 @@
 
   <!-- Imagen -->
   <div class="w-full">
-    <img
+    <Image
       src="/HydraulicPipe.webp"
       alt="Tubería Hidráulica"
       class="rounded-xl w-full object-cover shadow-md"
+      width={800}
+      height={600}
+      loading="lazy"
     />
   </div>
 </div>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -11,7 +11,7 @@ import "@/src/styles/global.css";
 
 const navData = await fetchTopSection();
 const footerData = await fetchFooter();
-const { title } = Astro.props;
+const { title, description = "Soluciones industriales en chillers, HVAC y mantenimiento" } = Astro.props;
 ---
 
 <!doctype html>
@@ -19,6 +19,7 @@ const { title } = Astro.props;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
     <!-- Google Tag Manager -->

--- a/src/layouts/ServiceLayout.astro
+++ b/src/layouts/ServiceLayout.astro
@@ -11,7 +11,7 @@ import "@/src/styles/global.css";
 
 const navData = await fetchTopSection();
 const footerData = await fetchFooter();
-const { title } = Astro.props;
+const { title, description = "Servicios industriales en chillers y HVAC" } = Astro.props;
 ---
 
 <!doctype html>
@@ -19,6 +19,7 @@ const { title } = Astro.props;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>{title}</title>
     <ClientRouter />

--- a/src/pages/about-us.astro
+++ b/src/pages/about-us.astro
@@ -11,9 +11,21 @@ import { fetchHeroSectionById } from "@/src/utils/queries/fetchHeroSection";
 const heroData = await fetchHeroSectionById(288);
 ---
 
-<MainLayout title="MAZ - Sobre nosotros">
+<MainLayout
+  title="MAZ - Sobre nosotros"
+  description="Conoce al equipo de MAZ y nuestra experiencia en mantenimiento y proyectos HVAC"
+>
   <HeroSection {...heroData} />
   <HeaderAbout />
   <AboutGrid />
   <ServicesGrid services={services} />
 </MainLayout>
+
+<!-- Invitación a contacto -->
+<section class="text-center py-8">
+  <p class="text-lg">
+    ¿Tienes un proyecto en puerta?&nbsp;
+    <a href="/contact" class="text-[#24408d] font-semibold underline">Contáctanos</a>
+    para recibir atención especializada.
+  </p>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,10 @@ import WhyUs from "@/src/components/common/WhyUs.astro";
 import FAQ from "@/src/components/common/FAQ.astro";
 ---
 
-<MainLayout title="MAZ - Soluciones de agua helada">
+<MainLayout
+  title="MAZ - Soluciones de agua helada"
+  description="Servicios de instalación, mantenimiento y venta de chillers industriales en México"
+>
   <HeroCarousel />
   <Welcome />
   <Products />

--- a/src/pages/services/chillers.astro
+++ b/src/pages/services/chillers.astro
@@ -8,7 +8,10 @@ import { fetchHeroSectionById } from "@/src/utils/queries/fetchHeroSection";
 const heroData = await fetchHeroSectionById(290);
 ---
 
-<ServiceLayout title="MAZ - Servicios para Chillers">
+<ServiceLayout
+  title="MAZ - Servicios para Chillers"
+  description="Instalación, mantenimiento y reparación especializada de chillers industriales"
+>
   <HeroSection {...heroData} />
   <ChillersLanding />
 </ServiceLayout>


### PR DESCRIPTION
## Summary
- add optional description meta tag in layouts
- link to external Ecochillers site
- convert hydraulic landing image to Astro `<Image>`
- provide descriptions for main pages
- add contact callout on About Us

## Testing
- `pnpm build` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_684b1cab6fa4832586daaaf7804d20b8